### PR TITLE
Fix a bug in sd_upscale_img2img

### DIFF
--- a/auto1111sdk/pipelines/StableDiffusionPipeline.py
+++ b/auto1111sdk/pipelines/StableDiffusionPipeline.py
@@ -322,7 +322,7 @@ class StableDiffusionPipeline:
         return output_images
     
     def sd_upscale_img2img(self, prompt: str, init_image: Image, upscaler = None, overlap: int = 64, scale_factor: int = 2, negative_prompt: str = "", seed: int = -1, steps: int = 20, cfg_scale: float = 7.0, num_images: int = 1, sampler_name: str = 'Euler', denoising_strength: float = 0.75):
-        if isinstance(upscaler, (EsrganPipeline, RealEsrganPipeline)):
+        if not isinstance(upscaler, (EsrganPipeline, RealEsrganPipeline)):
             raise ValueError("Upscaler should either be an instance of RealEsrgan pipeline or Esrgan pipeline")
         input_params = { 
             'init_images': [init_image], 


### PR DESCRIPTION
Should only raise an error if `upscaler` is **NOT** an instance of either `EsrganPipeline` or `RealEsrganPipeline`